### PR TITLE
Add base Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+install:
+  - docker build -t quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} .
+
+script:
+  - "/bin/true"
+
+before_deploy:
+  - docker login -e . -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io
+
+deploy:
+- provider: script
+  script: ".travis/deploy.sh"
+  on:
+    repo: azavea/docker-postgis
+    branch: develop
+- provider: script
+  script: ".travis/deploy.sh"
+  on:
+    repo: azavea/docker-postgis
+    tags: true
+
+notifications:
+  slack:
+    secure: CzjUAJ5h/p7UCz02KxCHuKjoVP+G0rwDTZFzXqs4AAENhoNL4vfwJaDD5XHeV03qwgxuRfE7A/2kO1sJ8B6tx0B7pUeN/Ahn8azw+O4b7cdjZy4qo2ZNwJfo5aYdprpiG/HjcNnRzcLOu2NTd9fWZ9eByuYpIjfGjfsrfRvgM1+DwMfLX1Jux89BC2BiwHkVbSa3Cyu8qWTfaU0V/2M0G7FjE5ZCDrH6UP5++PP3aYwTUGo9eAjPOc2qDytU3GYZgaVH8Nh/Vv4bl20qXYySiCKPhmwX533xCRqAI/Qg2wmOuwerGzPgIFNHR0h0xcDTbsBT0YZmnw3PT5YMgMJbEsocRfF33HeChpu/83qhq/s94MyaRtnIcM9aLeXQcOfLRs1lysY9fu8gWeWfEsNXJEeo1+6MqG/Kiv0fIRIiMo0yqn/v/fzXt50ATqxYGM+v9Zi/vXEEhwdt77JcMbUm7UQIQjPJYVG6SewQuDqvnSc1piDmkVAeHzH2Mf5FbJbpcZT44UHtondYnKZZcWuXv2tz/ZGiUavZXDxyDPx94jpdnSq8xO7PV8r89kcBm1GCtCPX2ZLPaScawZ+NhgkT1seM22AuaSuifOOXVdspHBrDBd9/CGiqWJdaNgKRXW4qth9Su1+nbd8vGvnHHInG/48jgD+2tef5g1CmbmWbIio=

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  QUAY_TAG="${TRAVIS_COMMIT:0:7}"
+else
+  QUAY_TAG="${TRAVIS_TAG}"
+
+  docker tag -f "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7}" "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}"
+fi
+
+docker push "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}"
+docker tag -f "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}" "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:latest"
+docker push "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:latest"


### PR DESCRIPTION
Currently, Travis CI isn't actually running any tests (only `/bin/true`), but that can easily be updated in `.travis.yml`.

More interesting is that Travis CI is setup to build and publish container images (to Quay) for all merges into `develop` using the first seven characters of the Git commit as the container image's tag. Git tag
pushes also produce container images, which are identified by the same version number of the tag.

See also:

  - https://quay.io/repository/azavea/postgis
  - https://travis-ci.org/azavea/docker-postgis