### PR TITLE
Update to postgresql 9.6 and postgis 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM postgres:9.5
+FROM postgres:9.6
 
 MAINTAINER Azavea <systems@azavea.com>
 
-ENV POSTGIS_MAJOR 2.2
-ENV POSTGIS_VERSION 2.2.2*pgdg80+1
+ENV POSTGIS_MAJOR 2.3
+ENV POSTGIS_VERSION 2.3.0*pgdg80+1
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
             postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
It looks like the postgis.control file normally found in
`/usr/share/postgresql/9.6/extension/postgis.control` is
now installed via the postgresql-PG_VERSION-postgis-POSTGIS_VERSION-scripts
package, not in the base package.

A Django installation failed on initial migrations without this additional package
installed in the container.