### PR TITLE
Add PostgreSQL 12.4 with PostGIS 3.x to build matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,6 +11,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         pg_major: ["9.6", "10.9", "11.4", "12.2", "12.4"]
         variant: [slim]

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_major: ["9.6", "10.9", "11.4", "12.2"]
+        pg_major: ["9.6", "10.9", "11.4", "12.2", "12.4"]
         variant: [slim]
         include:
           - pg_major: "9.6"
@@ -26,7 +26,10 @@ jobs:
             postgis_version: 2.5.4+dfsg-1.pgdg90+1
           - pg_major: "12.2"
             postgis_major: "3"
-            postgis_version: 3.0.1+dfsg-4.pgdg100+1
+            postgis_version: 3.0.2+dfsg-2.pgdg100+1
+          - pg_major: "12.4"
+            postgis_major: "3"
+            postgis_version: 3.0.2+dfsg-2.pgdg100+1
     env:
       DOCKER_BUILDKIT: 1
       PG_MAJOR: ${{ matrix.pg_major }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -24,7 +24,7 @@ jobs:
             postgis_version: 2.4.4+dfsg-4.pgdg90+1
           - pg_major: "11.4"
             postgis_major: "2.5"
-            postgis_version: 2.5.4+dfsg-1.pgdg90+1
+            postgis_version: 2.5.5+dfsg-1.pgdg90+1
           - pg_major: "12.2"
             postgis_major: "3"
             postgis_version: 3.0.2+dfsg-2.pgdg100+1

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ This optional environment variable can be used to send arguments to `postgres in
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 POSTGIS_MAJOR=2.5 POSTGIS_VERSION=2.5.2+dfsg-1~exp1.pgdg90+1 \
-  PG_MAJOR=11.4 VARIANT=slim \
+$ CI=1 POSTGIS_MAJOR=3 POSTGIS_VERSION=3.0.2+dfsg-2.pgdg100+1 \
+  PG_MAJOR=12.4 VARIANT=slim \
   ./scripts/cibuild
 ```
 


### PR DESCRIPTION
Add an item to the build matrix for PostgreSQL 12.4 and PostGIS 3.x.

---

### Testing

See: https://github.com/azavea/docker-postgis/actions/runs/296623284