### PR TITLE
Add PostGIS 3.0.3 with PostgreSQL 13.3 to build matrix 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile-*.template linguist-language=Dockerfile

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg_major: ["9.6", "10.9", "11.4", "12.2", "12.4"]
+        pg_major: ["9.6", "10.9", "11.4", "12.2", "12.4", "13.3"]
         variant: [slim]
         include:
           - pg_major: "9.6"
@@ -32,6 +32,9 @@ jobs:
           - pg_major: "12.4"
             postgis_major: "3"
             postgis_version: 3.0.2+dfsg-2.pgdg100+1
+          - pg_major: "13.3"
+            postgis_major: "3"
+            postgis_version: 3.0.3+dfsg-2.pgdg100+1
     env:
       DOCKER_BUILDKIT: 1
       PG_MAJOR: ${{ matrix.pg_major }}

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -3,8 +3,31 @@ FROM postgres:%%PG_MAJOR%%
 ENV POSTGIS_MAJOR %%POSTGIS_MAJOR%%
 ENV POSTGIS_VERSION %%POSTGIS_VERSION%%
 
-RUN \
-      apt-get update && apt-get install -y --no-install-recommends \
-              postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-              postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
-      && rm -rf /var/lib/apt/lists/*
+RUN set -ex \
+    # RDS usually lags behind the version of PostGIS maintained in the main
+    # repository. ca-certificates is required due to a 301 HTTP → HTTPS redirect
+    # from apt-archive.postgresql.org. apt-transport-https is required for
+    # stretch-based images (9.6, 10.9, and 11.4).
+    && apt-get update && apt-get install -y apt-transport-https ca-certificates --no-install-recommends \
+    && versionCodename=$(env -i bash -c ". /etc/os-release; echo \$VERSION | sed 's/.*(\(.*\))/\1/'") \
+    && echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ $versionCodename-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
+    && apt-get update \
+    # Pin PostgreSQL-specific packages so that we can upgrade the underlying OS
+    # (e.g., apt --installed list | grep pgdg).
+    && pinnedDeps=" \
+        libpq5 \
+        postgresql-$PG_MAJOR \
+        postgresql-client-$PG_MAJOR \
+        postgresql-client-common \
+        postgresql-common \
+    " \
+    && apt-mark hold $pinnedDeps && apt-get upgrade -y && apt-mark unhold $pinnedDeps \
+    # Now that we've installed ca-certificates and apt-transport-https,
+    # configured the archive repository, and updated Debian, we can install
+    # PostGIS.
+    && apt-get install -y --no-install-recommends \
+        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+    # Purge build dependencies and clean up package state.
+    && apt-get purge -y --auto-remove apt-transport-https ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ This optional environment variable can be used to send arguments to `postgres in
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 POSTGIS_MAJOR=3 POSTGIS_VERSION=3.0.2+dfsg-2.pgdg100+1 \
-  PG_MAJOR=12.4 VARIANT=slim \
+$ CI=1 POSTGIS_MAJOR=3 POSTGIS_VERSION=3.0.3+dfsg-2.pgdg100+1 \
+  PG_MAJOR=13.3 VARIANT=slim \
   ./scripts/cibuild
 ```
 

--- a/scripts/test
+++ b/scripts/test
@@ -19,13 +19,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         docker \
-            run -d --name postgres-test -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 "quay.io/azavea/postgis:$POSTGIS_MAJOR-postgres$PG_MAJOR-$VARIANT"
+            run -d --name postgres-test -e POSTGRES_HOST_AUTH_METHOD=trust "quay.io/azavea/postgis:$POSTGIS_MAJOR-postgres$PG_MAJOR-$VARIANT"
 
         sleep 5
 
-        psql -U postgres -h localhost -c "CREATE EXTENSION postgis;"
+        trap "docker rm -f postgres-test" EXIT
 
-        docker stop postgres-test
-        docker rm postgres-test
+        docker exec postgres-test psql -U postgres -c "SELECT version();"
+        docker exec postgres-test psql -U postgres -c "CREATE EXTENSION postgis;"
+        docker exec postgres-test psql -U postgres -c "SELECT PostGIS_Full_Version();"
+        (( $(docker exec postgres-test psql -U postgres --no-align --tuples-only -c "SELECT ST_X(ST_Point(0,0));") == 0 ))
     fi
 fi


### PR DESCRIPTION
The [PGDG main APT repository](https://wiki.postgresql.org/wiki/Apt) only contains the most recent version of PostgreSQL or PostGIS (for a particular PG version). To achieve parity with the version of PostGIS [available on RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.PostGIS.html#CHAP_PostgreSQL.Extensions.PostGIS), I configured the archive repository. 

Now, we can add an item to the build matrix for PostgreSQL 13.3 and PostGIS 3.0.3.

See: https://www.postgresql.org/about/news/announcing-apt-archivepostgresqlorg-2024/ 

---

**Testing**

See: https://github.com/azavea/docker-postgis/actions/runs/1175800553